### PR TITLE
Fixes for issue #5,#6 - not handling null objects - duplicate object …

### DIFF
--- a/soapclient.js
+++ b/soapclient.js
@@ -71,6 +71,14 @@ SOAPClientParameters._serialize = function(t, o)
             s += "</" + t + ">";
             break;
         case "object":
+			//	if the object is null just output an empty tag
+			if( o === null )
+			{
+				s += "<" + t + ">";
+				s += "</" + t + ">";
+				break;
+			}
+			
             // Date
             if(o.constructor.toString().indexOf("function Date()") > -1)
             {
@@ -140,12 +148,12 @@ SOAPClientParameters._serialize = function(t, o)
             }
             // Object or custom function
             else
-                for(var p in o)
-                {
-                    s += "<" + t + ">";
-                    s += SOAPClientParameters._serialize(p, o[p]);
-                    s += "</" + t + ">";
-                }
+			{
+				s += "<" + t + ">";
+				for(var p in o)
+					s += SOAPClientParameters._serialize(p, o[p]);
+				s += "</" + t + ">";
+			}
             break;
         default:
             break; // throw new Error(500, "SOAPClientParameters: type '" + typeof(o) + "' is not supported");


### PR DESCRIPTION
…tags around properties

added a check during serialization to see if the object is null so it
will output an empty tag set.

Modified serialization of general objects to only output outer tags once
not for each property.